### PR TITLE
fix: missing timer arg to setTimeout (#14)

### DIFF
--- a/src/components/ui/colorcard/ColorCard.tsx
+++ b/src/components/ui/colorcard/ColorCard.tsx
@@ -15,7 +15,7 @@ const ColorCard = ({ backgroundColor }: ColorCardProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const copied = () => setIsCopied(false);
 
-  const displayIsCopied = setTimeout(copied,  );
+  const displayIsCopied = setTimeout(copied, 1000);
   const releaseDisplayedIsCopied = () => clearTimeout(displayIsCopied);
 
   return (


### PR DESCRIPTION
# Type of Change

- [x] Bug Fix (change that fixed a bug)

###

# Description

The copied to clipboard text to tell the users that the text is copied is disappearing immediately. This occurs because of the missing second argument in setTimeout therefor resulting to this bug.

###

# Related Tickets

- Related Issue(s) #
- Closes #14 

###

# How Has This Been Tested?

* Performance testing
   1. run the dev server locally and check for the changes

**Test Configuration**:

- Browser: Google Chrome
- Browser version: 125.0.6422.142 (Official Build) (64-bit)
- Text editor: Visual Studio Code
